### PR TITLE
fix: fall back to unstaged diff for gptel commit messages

### DIFF
--- a/lisp/editor-vsc.el
+++ b/lisp/editor-vsc.el
@@ -62,7 +62,7 @@
 
   ;; https://github.com/LuciusChen/.emacs.d/blob/main/lib/lib-magit.el
   (defconst gptel-commit-prompt
-    "The user provides the result of running `git diff --cached`. You suggest a conventional commit message. Don't add anything else to the response. The following describes conventional commits.
+    "The user provides the result of running `git diff --cached` or `git diff`. You suggest a conventional commit message. Don't add anything else to the response. The following describes conventional commits.
 
 # Conventional Commits 1.0.0
 
@@ -108,6 +108,9 @@ A scope may be provided to a commit's type, to provide additional contextual inf
     (interactive)
     (require 'gptel)
     (let* ((lines (magit-git-lines "diff" "--cached"))
+           (lines (if (null lines)
+                      (magit-git-lines "diff")
+                    lines))
            (changes (string-join lines "\n")))
       (gptel-request changes :system gptel-commit-prompt)))
 


### PR DESCRIPTION
### Motivation
- `gptel-commit` previously only used the output of `git diff --cached`, which yields no input when there are no staged changes and prevented generation from unstaged diffs.

### Description
- Update `gptel-commit-prompt` to state it accepts output from `git diff --cached` or `git diff`.
- Change `gptel-commit` to call `(magit-git-lines "diff")` when `(magit-git-lines "diff" "--cached")` returns `nil`, and then join the lines into `changes` for the request.
- Minor implementation detail: check for `nil` on the `lines` result to detect an empty cached-diff response.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698832ffb7f8832fa136412042006565)